### PR TITLE
Add retargeting support for obfuscated classes/fields/methods

### DIFF
--- a/tool/src/main/java/lanchon/dexpatcher/Processor.java
+++ b/tool/src/main/java/lanchon/dexpatcher/Processor.java
@@ -69,7 +69,7 @@ public class Processor {
 		}
 
 		for (String patchFile : config.patchFiles) {
-			DexFile patchDex = readDex(new File(patchFile));
+			DexFile patchDex = retargeter.rewrite(readDex(new File(patchFile)));
 			types += patchDex.getClasses().size();
 			dex = processDex(dex, patchDex);
 		}

--- a/tool/src/main/java/lanchon/dexpatcher/Processor.java
+++ b/tool/src/main/java/lanchon/dexpatcher/Processor.java
@@ -15,10 +15,12 @@ import java.io.IOException;
 
 import lanchon.dexpatcher.core.Context;
 import lanchon.dexpatcher.core.DexPatcher;
+import lanchon.dexpatcher.core.PatchException;
+import lanchon.dexpatcher.core.Retargeter;
 import lanchon.dexpatcher.core.logger.Logger;
 import lanchon.multidexlib2.BasicDexFileNamer;
-import lanchon.multidexlib2.DexIO;
 import lanchon.multidexlib2.DexFileNamer;
+import lanchon.multidexlib2.DexIO;
 import lanchon.multidexlib2.MultiDexIO;
 import lanchon.multidexlib2.OpcodeUtils;
 import lanchon.multidexlib2.SingletonDexContainer;
@@ -55,6 +57,16 @@ public class Processor {
 
 		DexFile dex = readDex(new File(config.sourceFile));
 		int types = dex.getClasses().size();
+
+		Retargeter retargeter = new Retargeter(createContext());
+
+		try {
+			for (String patchFile : config.patchFiles) {
+				retargeter.populateTargetMap(readDex(new File(patchFile)));
+			}
+		} catch (PatchException e) {
+			logger.log(ERROR, "Exception while populating target map: " + e.getMessage());
+		}
 
 		for (String patchFile : config.patchFiles) {
 			DexFile patchDex = readDex(new File(patchFile));

--- a/tool/src/main/java/lanchon/dexpatcher/core/Retargeter.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/Retargeter.java
@@ -1,0 +1,113 @@
+/*
+ * DexPatcher - Copyright 2015-2017 Rodrigo Balerdi
+ * (GNU General Public License version 3 or later)
+ *
+ * DexPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ */
+
+package lanchon.dexpatcher.core;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lanchon.dexpatcher.core.logger.Logger;
+import lanchon.dexpatcher.core.model.Targets;
+import lanchon.dexpatcher.core.patcher.ClassSetPatcher;
+import lanchon.dexpatcher.core.patcher.FieldSetPatcher;
+import lanchon.dexpatcher.core.patcher.MemberSetPatcher;
+import lanchon.dexpatcher.core.patcher.MethodSetPatcher;
+
+import org.jf.dexlib2.iface.ClassDef;
+import org.jf.dexlib2.iface.DexFile;
+import org.jf.dexlib2.iface.Field;
+import org.jf.dexlib2.iface.Member;
+import org.jf.dexlib2.iface.Method;
+
+import static lanchon.dexpatcher.core.logger.Logger.Level.*;
+
+public class Retargeter {
+
+	Targets targets;
+	Context context;
+	Logger logger;
+
+	public Retargeter(Context context) {
+		this.targets = new Targets();
+		this.context = context;
+		this.logger = context.getLogger();
+	}
+
+	// Creates the source => target mapping for class types and fields/methods names,
+	// this needs to be called before retartget()
+	public void populateTargetMap(DexFile patchDex) throws PatchException {
+		for (ClassDef patchClass : patchDex.getClasses()) {
+			ClassSetPatcher classSetPatcher = new ClassSetPatcher(context);
+
+			String classPatchId = classSetPatcher.getId(patchClass);
+
+			PatcherAnnotation classActionContext = classSetPatcher.getActionContext(classPatchId, patchClass);
+
+			if (!shouldRetarget(classActionContext)) {
+				continue;
+			}
+
+			targets.addClass(classPatchId);
+
+			String classTargetId = classSetPatcher.getTargetId(classPatchId, patchClass, classActionContext);
+
+			if (classPatchId != classTargetId) {
+				log(INFO, "Mapping class " + classPatchId + " => " + classTargetId);
+				targets.getTargetClass(classPatchId).target = classTargetId;
+			}
+
+			// Map class method and field names
+			for (Method patchMethod : patchClass.getMethods()) {
+				MethodSetPatcher methodSetPatcher = new MethodSetPatcher(classSetPatcher, classActionContext);
+
+				targets.getTargetClass(classPatchId).fields.putAll(getTargetMapping(methodSetPatcher, patchMethod));
+			}
+
+			for (Field patchField : patchClass.getFields()) {
+				FieldSetPatcher fieldSetPatcher = new FieldSetPatcher(classSetPatcher, classActionContext);
+
+				targets.getTargetClass(classPatchId).fields.putAll(getTargetMapping(fieldSetPatcher, patchField));
+			}
+		}
+	}
+
+	private <Member> Map<String, String> getTargetMapping(MemberSetPatcher<? super Member> memberPatcher, Member member) throws PatchException {
+		String memberPatchId = memberPatcher.getId(member);
+		PatcherAnnotation memberActionContext = memberPatcher.getActionContext(memberPatchId, member);
+		HashMap<String, String> targetMap = new HashMap<>();
+
+		if (!shouldRetarget(memberActionContext)) {
+			return targetMap;
+		}
+
+		String fieldTargetId = memberPatcher.getTargetId(memberPatchId, member, memberActionContext);
+		String targetName = memberActionContext.getTarget();
+
+		if (memberPatchId != fieldTargetId
+				&& targetName != null) {
+			log(INFO, "Mapping member " + memberPatchId + " => " + targetName);
+			targetMap.put(memberPatchId, targetName);
+		}
+
+		return targetMap;
+	}
+
+	private boolean shouldRetarget(PatcherAnnotation actionContext) {
+		return actionContext.getAction() == Action.EDIT
+				|| actionContext.getAction() == Action.REPLACE
+				|| actionContext.getAction() == Action.WRAP
+				|| actionContext.getAction() == Action.APPEND
+				|| actionContext.getAction() == Action.PREPEND;
+	}
+
+	protected void log(Logger.Level level, String message) {
+		logger.log(level, "Retargeter: " + message);
+	}
+}

--- a/tool/src/main/java/lanchon/dexpatcher/core/model/Targets.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/model/Targets.java
@@ -1,0 +1,56 @@
+/*
+ * DexPatcher - Copyright 2015-2017 Rodrigo Balerdi
+ * (GNU General Public License version 3 or later)
+ *
+ * DexPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ */
+
+package lanchon.dexpatcher.core.model;
+
+import java.util.HashMap;
+
+public class Targets {
+	private HashMap<String, TargetClass> classes;
+
+	public class TargetClass {
+		public String target;
+
+		// method id => target name
+		public HashMap<String, String> methods;
+
+		// field id => target name
+		public HashMap<String, String> fields;
+
+		public TargetClass(String patchTarget) {
+			this.target = patchTarget;
+			this.methods = new HashMap<>();
+			this.fields = new HashMap<>();
+
+		}
+	}
+
+	public Targets() {
+		this.classes = new HashMap<>();
+	}
+
+	public void addClass(String patchClass) {
+		if (this.classes.containsKey(patchClass)) {
+			return;
+		}
+
+		this.classes.put(patchClass, new TargetClass(patchClass));
+	}
+
+	public TargetClass getTargetClass(String patchClass) {
+		TargetClass targetClass = this.classes.get(patchClass);
+
+		if (targetClass == null) {
+			targetClass = new TargetClass(patchClass);
+		}
+
+		return targetClass;
+	}
+}

--- a/tool/src/main/java/lanchon/dexpatcher/core/model/Targets.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/model/Targets.java
@@ -10,7 +10,15 @@
 
 package lanchon.dexpatcher.core.model;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+
+import lanchon.dexpatcher.core.util.Id;
+
+import org.jf.dexlib2.iface.MethodParameter;
+import org.jf.dexlib2.iface.reference.FieldReference;
+import org.jf.dexlib2.iface.reference.MethodReference;
 
 public class Targets {
 	private HashMap<String, TargetClass> classes;
@@ -34,6 +42,32 @@ public class Targets {
 
 	public Targets() {
 		this.classes = new HashMap<>();
+	}
+
+	public String getRetargetedClassName(String originalType) {
+		return getTargetClass(originalType).target;
+	}
+
+	public String getRetargetedFieldName(FieldReference field) {
+		TargetClass targetClass = getTargetClass(field.getDefiningClass());
+		String fieldName = targetClass.fields.get(Id.ofField(field));
+
+		if (fieldName == null) {
+			fieldName = field.getName();
+		}
+
+		return fieldName;
+	}
+
+	public String getRetargetedMethodName(MethodReference method) {
+		TargetClass targetClass = getTargetClass(method.getDefiningClass());
+		String methodName = targetClass.fields.get(Id.ofMethod(method));
+
+		if (methodName == null) {
+			methodName = method.getName();
+		}
+
+		return methodName;
 	}
 
 	public void addClass(String patchClass) {

--- a/tool/src/main/java/lanchon/dexpatcher/core/model/Targets.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/model/Targets.java
@@ -45,6 +45,11 @@ public class Targets {
 	}
 
 	public String getRetargetedClassName(String originalType) {
+		// Need to manually handle arrays of objects
+		if (originalType.startsWith("[")) {
+			return "[" + getTargetClass(originalType.substring(1)).target;
+		}
+
 		return getTargetClass(originalType).target;
 	}
 

--- a/tool/src/main/java/lanchon/dexpatcher/core/patcher/AbstractPatcher.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/patcher/AbstractPatcher.java
@@ -187,7 +187,7 @@ public abstract class AbstractPatcher<T> {
 
 	// Handlers
 
-	protected abstract String getId(T item);
+	public abstract String getId(T item);
 	protected abstract void setupLogPrefix(String id, T item, T patch, T patched);
 
 	protected abstract void onPatch(String patchId, T patch) throws PatchException;

--- a/tool/src/main/java/lanchon/dexpatcher/core/patcher/AbstractPatcher.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/patcher/AbstractPatcher.java
@@ -38,7 +38,7 @@ public abstract class AbstractPatcher<T> {
 
 	private String logPrefix;
 
-	private LinkedHashMap<String, T> sourceMap;
+	private LinkedHashMap<String, T> sourceMap = new LinkedHashMap<>();
 	private LinkedHashMap<String, Boolean> targetedMap;
 	private LinkedHashMap<String, PatchedItem<T>> patchedMap;
 

--- a/tool/src/main/java/lanchon/dexpatcher/core/patcher/ActionBasedPatcher.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/patcher/ActionBasedPatcher.java
@@ -111,7 +111,7 @@ public abstract class ActionBasedPatcher<T, C extends ActionBasedPatcher.ActionC
 
 	protected abstract C getActionContext(String patchId, T patch) throws PatchException;
 	protected void onPrepare(String patchId, T patch, C actionContext) throws PatchException {}
-	protected abstract String getTargetId(String patchId, T patch, C actionContext) throws PatchException;
+	public abstract String getTargetId(String patchId, T patch, C actionContext) throws PatchException;
 
 	protected abstract T onSimpleAdd(T patch, C actionContext);
 	protected abstract T onSimpleEdit(T patch, C actionContext, T target, boolean inPlace);

--- a/tool/src/main/java/lanchon/dexpatcher/core/patcher/AnnotatableSetPatcher.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/patcher/AnnotatableSetPatcher.java
@@ -97,7 +97,7 @@ public abstract class AnnotatableSetPatcher<T extends Annotatable> extends Actio
 	// Implementation
 
 	@Override
-	protected PatcherAnnotation getActionContext(String patchId, T patch) throws PatchException {
+	public PatcherAnnotation getActionContext(String patchId, T patch) throws PatchException {
 		Set<? extends Annotation> rawAnnotations = patch.getAnnotations();
 		PatcherAnnotation annotation = PatcherAnnotation.parse(getContext(), rawAnnotations);
 		if (annotation == null) annotation = new PatcherAnnotation(getDefaultAction(patchId, patch), rawAnnotations);

--- a/tool/src/main/java/lanchon/dexpatcher/core/patcher/ClassSetPatcher.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/patcher/ClassSetPatcher.java
@@ -58,7 +58,7 @@ public class ClassSetPatcher extends AnnotatableSetPatcher<ClassDef> {
 	// Implementation
 
 	@Override
-	protected final String getId(ClassDef item) {
+	public final String getId(ClassDef item) {
 		return Id.ofClass(item);
 	}
 
@@ -86,7 +86,7 @@ public class ClassSetPatcher extends AnnotatableSetPatcher<ClassDef> {
 	}
 
 	@Override
-	protected String getTargetId(String patchId, ClassDef patch, PatcherAnnotation annotation) {
+	public String getTargetId(String patchId, ClassDef patch, PatcherAnnotation annotation) {
 		String targetId = patchId;
 		String target = annotation.getTarget();
 		String targetClass = annotation.getTargetClass();

--- a/tool/src/main/java/lanchon/dexpatcher/core/patcher/FieldSetPatcher.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/patcher/FieldSetPatcher.java
@@ -42,7 +42,7 @@ public class FieldSetPatcher extends MemberSetPatcher<Field> {
 	// Implementation
 
 	@Override
-	protected final String getId(Field item) {
+	public final String getId(Field item) {
 		return Id.ofField(item);
 	}
 
@@ -58,7 +58,7 @@ public class FieldSetPatcher extends MemberSetPatcher<Field> {
 	}
 
 	@Override
-	protected String getTargetId(String patchId, Field patch, PatcherAnnotation annotation) {
+	public String getTargetId(String patchId, Field patch, PatcherAnnotation annotation) {
 		String target = annotation.getTarget();
 		String targetId = (target != null) ? Id.ofField(patch, target) : patchId;
 		if (shouldLogTarget(patchId, targetId)) {

--- a/tool/src/main/java/lanchon/dexpatcher/core/patcher/MethodSetPatcher.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/patcher/MethodSetPatcher.java
@@ -122,7 +122,7 @@ public class MethodSetPatcher extends MemberSetPatcher<Method> {
 	}
 
 	@Override
-	protected final String getId(Method item) {
+	public final String getId(Method item) {
 		return Id.ofMethod(item);
 	}
 
@@ -153,7 +153,7 @@ public class MethodSetPatcher extends MemberSetPatcher<Method> {
 	}
 
 	@Override
-	protected String getTargetId(String patchId, Method patch, PatcherAnnotation annotation) {
+	public String getTargetId(String patchId, Method patch, PatcherAnnotation annotation) {
 		String target = annotation.getTarget();
 		String resolvedTarget = (target != null) ? target : patch.getName();
 		String targetId;

--- a/tool/src/main/java/lanchon/dexpatcher/core/util/Id.java
+++ b/tool/src/main/java/lanchon/dexpatcher/core/util/Id.java
@@ -10,6 +10,7 @@
 
 package lanchon.dexpatcher.core.util;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import lanchon.dexpatcher.core.Marker;
@@ -18,6 +19,8 @@ import org.jf.dexlib2.iface.ClassDef;
 import org.jf.dexlib2.iface.Field;
 import org.jf.dexlib2.iface.Method;
 import org.jf.dexlib2.iface.MethodParameter;
+import org.jf.dexlib2.iface.reference.FieldReference;
+import org.jf.dexlib2.iface.reference.MethodReference;
 
 public class Id {
 
@@ -41,7 +44,15 @@ public class Id {
 	}
 
 	public static String ofField(Field field, String name) {
-		return name + '.' + field.getType();
+		return ofField(field.getType(), name);
+	}
+
+	public static String ofField(FieldReference field) {
+		return ofField(field.getType(), field.getName());
+	}
+
+	public static String ofField(String type, String name) {
+		return name + '.' + type;
 	}
 
 	public static String ofMethod(Method method) {
@@ -53,9 +64,23 @@ public class Id {
 	}
 
 	public static String ofMethod(List<? extends MethodParameter> parameters, String returnType, String name) {
+		List<String> stringParameters = new ArrayList<>();
+
+		for (MethodParameter p : parameters) {
+			stringParameters.add(p.getType());
+		}
+
+		return ofMethodInternal(stringParameters, returnType, name);
+	}
+
+	public static String ofMethod(MethodReference method) {
+		return ofMethodInternal(method.getParameterTypes(), method.getReturnType(), method.getName());
+	}
+
+	private static String ofMethodInternal(List<? extends CharSequence> parameters, String returnType, String name) {
 		StringBuilder sb = new StringBuilder();
 		sb.append(name).append('.');
-		for (MethodParameter p : parameters) sb.append(p.getType());
+		for (CharSequence p : parameters) sb.append(p);
 		sb.append('.').append(returnType);
 		return sb.toString();
 	}


### PR DESCRIPTION
This PR allows dexpatcher to transparently rename targeted class, method and field references in:
* Class definitions (parent class types and implementation types)
* Field definitions (field types)
* Method definitions (parameter types and return types)
* Method implementations (references to classes, fields or methods that have been targeted)

It builds a map of targets from the patch file, then rewrites the patch file with the new targets before applying it.

So effectively it will make this:

```
@DexEdit(target = "ro.numedecod.a.e.a.a", contentOnly = true)
public class a__ {

    @DexEdit(target = "ro.numedecod.a.e.a.a$c", contentOnly = true)
    public class c extends ro.numedecod.a.e.a_.b_ {

        @DexEdit(target = "b")
        private List<a_nalUnitInfo> b_sequenceParameterSetList = new ArrayList();

        @DexEdit(target = "c")
        private List<a_nalUnitInfo> c_pictureParameterSetList = new ArrayList();

        @DexReplace(target = "a")
        public final byte a_getVideoProfile() {
            return this.a_bytestreamBeginning[this.b_sequenceParameterSetList.get(0).a_nalUnitHeaderIndex + 1];
        }


        @DexReplace(target = "a")
        final void a_keepInformationFromNalUnitHeader(a_nalUnitInfo nalUnitInfo) {
            // Get the NAL unit type
            switch(this.a_bytestreamBeginning[nalUnitInfo.a_nalUnitHeaderIndex] & 15) {
                case 7:     // sequence parameter set
                    this.b_sequenceParameterSetList.add(nalUnitInfo);
                    break;
                case 8:     // picture parameter set
                    this.c_pictureParameterSetList.add(nalUnitInfo);
            }
        }
    }
}
```

As if you had written this (which may not have been be syntactically correct at compile time): 

```
@DexEdit(contentOnly = true)
public class a {

    @DexEdit(contentOnly = true)
    public class c extends ro.numedecod.a.e.a.b {

        @DexEdit
        private List<a> b = new ArrayList();

        @DexEdit
        private List<a> c = new ArrayList();

        @DexReplace
        public final byte a() {
            return this.a[this.b.get(0).a + 1];
        }


        @DexReplace
        final void a(a nalUnitInfo) {
            // Get the NAL unit type
            switch(this.a[nalUnitInfo.a] & 15) {
                case 7:     // sequence parameter set
                    this.b.add(nalUnitInfo);
                    break;
                case 8:     // picture parameter set
                    this.c.add(nalUnitInfo);
            }
        }
    }
}
```

The main benefit being that proguarded code can be annotated (which makes understanding what's going on much easier) and edited.

There are a few edge cases I've come across that still need to narrow down:
  - [ ] Nested classes need to have their full name targeted
     * `@DexEdit(target = "ro.numedecod.a.e.a.a$c")` works, but `@DexEdit(target = "a$c")` doesn't
  - [ ] Nested classes need to be defined inside a properly targeted parent class or they don't compile with the right type information
  - [ ] Nested class <init> seem to have a "hidden" first method parameter with a reference to their parent class that I don't seem to get when building the target map. I think it's caused by my shortcutting of a lot of the process logic.
     * At the moment I'm working around this by using `defaultAction = DexAction.IGNORE` to skip the method since there doesn't seem to be a way to define it to specifically `@DexIgnore`.

Also I haven't been able to get the tests running (I'm developing on windows - not sure if that has anything to do with it), but would like to add some for the more obscure stuff.

Resolves #27 